### PR TITLE
Add OS default fonts for Ubuntu (Unity) and Fedora (GNOME 3)

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -164,7 +164,7 @@
 
 // Font
 
-@font-family: 'Lucida Grande', 'Segoe UI', sans-serif;
+@font-family: 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
 
 
 // Settings View


### PR DESCRIPTION
This adds OS default fonts for the Linux distros Ubuntu and Fedora (or anyone else using GNOME 3). Since Lucida Grande and Segoe UI are generally only available in their native OSes (OS X and Windows respectively), the `sans-serif` fallback was being used as the main UI font.

Refs atom/one-dark-ui#13 atom/atom#4581