### PR TITLE
Themed markdown-preview

### DIFF
--- a/styles/packages.less
+++ b/styles/packages.less
@@ -56,8 +56,58 @@
 
 // markdown-preview ---------------------------
 .markdown-preview {
-  font-size: @font-size;
+  font-size: @font-size*1.25;
+  color: @text-color;
+  background-color: @base-background-color;
+
+  h1, h2 {
+    color: inherit;
+    border-color: @base-border-color;
+  }
+
+  a {
+    color: @text-color-highlight;
+  }
+
+  hr {
+    background-color: @text-color-subtle;
+  }
+
+  blockquote {
+    color: @text-color;
+    border-left-color: @text-color-subtle;
+  }
+
+  code {
+    color: lighten(@text-color, 20%);
+    border-color: @base-border-color;
+    background-color: lighten(@base-background-color, 10%);
+    background-clip: padding-box;
+  }
+
+  atom-text-editor {
+    background-color: @level-3-color;
+    &::shadow {
+      .lines {
+        background-color: @level-3-color;
+      }
+      .line.cursor-line {
+        background-color: transparent;
+      }
+    }
+  }
 }
+
+/* Active tab for default background
+.tab.active[data-type="MarkdownPreviewView"] {
+  color: @tab-text-color-editor;
+  background-color: #fff;
+  &:after {
+    border-bottom-color: #fff;
+  }
+}
+*/
+
 
 
 // git-control ---------------------------

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -67,11 +67,11 @@
   }
 
   a {
-    color: @text-color-highlight;
+    color: @text-color-info;
   }
 
   hr {
-    background-color: @text-color-subtle;
+    background-color: @markdown-preview-background-color;
   }
 
   blockquote {

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -57,8 +57,9 @@
 // markdown-preview ---------------------------
 .markdown-preview {
   font-size: @font-size*1.25;
-  color: @text-color;
-  background-color: @base-background-color;
+  color: @markdown-preview-color;
+  background-color: @markdown-preview-background-color;
+
 
   h1, h2 {
     color: inherit;
@@ -79,44 +80,23 @@
   }
 
   code {
-    color: lighten(@text-color, 20%);
+    color: @markdown-preview-code-color;
     border-color: @base-border-color;
-    background-color: lighten(@base-background-color, 10%);
+    background-color: @markdown-preview-code-background-color;
     background-clip: padding-box;
   }
 
-  atom-text-editor {
-    background-color: @level-3-color;
-    &::shadow {
-      .lines {
-        background-color: @level-3-color;
-      }
-      .line.cursor-line {
-        background-color: transparent;
-      }
+  atom-text-editor::shadow {
+    .line.cursor-line {
+      background-color: transparent;
     }
   }
 }
 
-/* Active tab for default background
+// Active tab for default background
 .tab.active[data-type="MarkdownPreviewView"] {
-  color: @tab-text-color-editor;
-  background-color: #fff;
+  background-color: @markdown-preview-background-color;
   &:after {
-    border-bottom-color: #fff;
-  }
-}
-*/
-
-
-
-// git-control ---------------------------
-.git-control {
-  background: @base-background-color;
-  .icon.large:before {
-    font-size: @component-icon-size*2;
-    line-height: @component-icon-size*2;
-    height: @component-icon-size*2;
-    margin-bottom: .25em;
+    border-bottom-color: @markdown-preview-background-color;
   }
 }

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -148,13 +148,6 @@
       border-bottom-color: @tab-background-color-editor;
     }
   }
-  .tab.active[data-type="MarkdownPreviewView"] {
-    color: @tab-text-color-editor;
-    background-color: #fff;
-    &:after {
-      border-bottom-color: #fff;
-    }
-  }
 
   .placeholder {
     margin: 0;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -168,9 +168,15 @@ html { font-size: 11px; }   // base font-size
 @font-family: 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
 
 
-// Settings View -------------------------------------
+// Packages -------------------------------------
 
 @settings-list-background-color: darken(@level-2-color, 3%);
 @theme-config-box-shadow: inset 0 1px 2px hsla(0, 0%, 0%, .2), 0 1px 0 hsla(0, 0%, 100%, .3);
 @theme-config-box-shadow-selected: inset 0 1px 3px hsla(0, 0%, 0%, .2);
 @theme-config-border-selected: hsla(0, 0%, 0%, .5);
+
+@markdown-preview-color: @text-color;
+@markdown-preview-background-color: lighten(@base-background-color, 3%);
+@markdown-preview-hr-color: lighten(@base-background-color, 3%);
+@markdown-preview-code-color: lighten(@text-color, 10%);
+@markdown-preview-code-background-color: darken(@base-background-color, 1%);


### PR DESCRIPTION
This PR uses some of the theme colors to style the markdown-preview. It's more noticable in the dark version: https://github.com/atom/one-dark-ui/pull/20

Before:

![screen shot 2015-03-17 at 11 17 36 am](https://cloud.githubusercontent.com/assets/378023/6680334/1c9a447c-cc99-11e4-8ea5-5418834a51ee.png)

After:

![screen shot 2015-03-17 at 11 28 15 am](https://cloud.githubusercontent.com/assets/378023/6680331/188d9fc8-cc99-11e4-82c1-d669f482fe8e.png)
