### PR TITLE
Saturation guards

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -3,15 +3,16 @@
 ** ---------------------------------------------- */
 
 @import "syntax-variables";
-
-// Config -----------------
 @ui-syntax-color: @syntax-background-color;
 
+// Color guards -----------------
 @ui-hue:          hue(@ui-syntax-color);
-@ui-saturation:   min( saturation(@ui-syntax-color), 24%);
-@ui-lightness:    max(  lightness(@ui-syntax-color), 92%);
+@ui-saturation:   min( saturation(@ui-syntax-color), 24%); // max saturation
+@ui-lightness:    max(  lightness(@ui-syntax-color), 92%); // min lightness
 
-@ui-color:        hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
+// Main colors -----------------
+@ui-fg: hsl(@ui-hue, @ui-saturation, @ui-lightness - 66%);
+@ui-bg: hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
 
 
 
@@ -24,7 +25,7 @@
 
 
 // Text -----------------
-@text-color:            hsl(@ui-hue, @ui-saturation, -70% + @ui-lightness);
+@text-color:            @ui-fg;
 @text-color-subtle:     fadeout(@text-color, 30%);
 @text-color-highlight:  hsl(@ui-hue, @ui-saturation + 20%, 30%);
 @text-color-selected:   darken(@text-color-highlight, 10%);
@@ -48,8 +49,8 @@
 
 
 // Base -----------------
-@base-background-color: @ui-color;
-@base-border-color:     darken(@ui-color, 15%);
+@base-background-color: @ui-bg;
+@base-border-color:     darken(@base-background-color, 15%);
 
 
 // Components -----------------

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -5,22 +5,13 @@
 @import "syntax-variables";
 
 // Config -----------------
-@ui-s:       @syntax-background-color;
-@ui-s-h:     hue(@ui-s);
-@ui-s-s:     min( saturation(@ui-s), 6%);
-@ui-s-l:     luma(@ui-s);
+@ui-syntax-color: @syntax-background-color;
 
-.ui-s-color() when (@ui-s-l >= 50%) { @ui-s-color: @ui-s; }
-.ui-s-color() when (@ui-s-l < 50%)  { @ui-s-color: hsl(@ui-s-h, @ui-s-s, 88%); }
-.ui-s-color(); // ^ Use @syntax-background-color if dark, otherwise only use hue + saturation
+@ui-hue:          hue(@ui-syntax-color);
+@ui-saturation:   min( saturation(@ui-syntax-color), 24%);
+@ui-lightness:    max(  lightness(@ui-syntax-color), 92%);
 
-
-// Main UI colors -----------------
-@ui-hue:          hue(@ui-s-color);
-@ui-saturation:   saturation(@ui-s-color);
-@ui-lightness:    lightness(@ui-s-color);
-@ui-color:        @ui-s-color; // normalized @syntax-background-color
-@ui-syntax-color: @ui-s;       // original @syntax-background-color
+@ui-color:        hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
 
 
 


### PR DESCRIPTION
This PR adds some color guards. Fixes https://github.com/atom/one-dark-ui/issues/22

It adds some saturation limits to stay somewhat toned down even if the Syntax background has a lot of saturation. Below an example for `One light` + `Solarized light`:

Before:
![screen shot 2015-03-20 at 10 42 34 am](https://cloud.githubusercontent.com/assets/378023/6744579/c3c11f76-ceee-11e4-9d67-6d80f697e505.png)

After:
![screen shot 2015-03-20 at 10 41 52 am](https://cloud.githubusercontent.com/assets/378023/6744581/cde35da2-ceee-11e4-9fce-de0aa2761ed7.png)

Also dark Syntax themes look less muddy and a bit brighter.