### PR TITLE
:art: Make font values more consistent

### DIFF
--- a/styles/key-binding.less
+++ b/styles/key-binding.less
@@ -3,7 +3,7 @@
   margin-left: @ui-padding-icon;
   padding: 0 @ui-padding/4;
   line-height: 2;
-  font-family: Helvetica Neue, Arial, sans-serif;
+  font-family: 'Helvetica Neue', Arial, sans-serif;
   font-size: max(1em, @ui-size*.85);
   letter-spacing: @ui-size/10;
   border-radius: @component-border-radius;

--- a/styles/tooltips.less
+++ b/styles/tooltips.less
@@ -18,7 +18,7 @@
   }
 
   .keystroke {
-    font-family: "Helvetica Neue", Arial, sans-serif;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
     font-size: max(1em, @ui-size*.85);
     padding: .1em .4em;
     margin: 0 @ui-padding*-.35 0 @ui-padding*.25;


### PR DESCRIPTION
All three font declarations in this theme were written differently: one with double quotes, one with single quotes and one with none. Using the declaration in `ui-variables.less` as a base, I changed the other two to use single quotes for consistency. It's the little things. :smiley: 