### PR TITLE
Remove Markdown Preview styling

### DIFF
--- a/styles/packages.less
+++ b/styles/packages.less
@@ -72,64 +72,6 @@
 }
 
 
-// markdown-preview ---------------------------
-
-.markdown-preview {
-  font-size: @ui-size*1.25;
-  color: @markdown-preview-color;
-  background-color: @markdown-preview-background-color;
-
-
-  h1, h2 {
-    color: inherit;
-    border-color: @base-border-color;
-  }
-
-  a {
-    color: @text-color-info;
-  }
-
-  hr {
-    background-color: @markdown-preview-hr-color;
-  }
-
-  blockquote {
-    color: @text-color;
-    border-left-color: @text-color-subtle;
-  }
-
-  table {
-    th,
-    td {
-      border-color: @base-border-color;
-    }
-    th {
-      background-color: lighten(@markdown-preview-background-color, 3%);
-    }
-    tr {
-      background-color: @markdown-preview-background-color;
-      &:nth-child(2n) {
-        background-color: darken(@markdown-preview-background-color, 3%);
-      }
-    }
-  }
-
-  code {
-    color: @markdown-preview-code-color;
-    border-color: @base-border-color;
-    background-color: @markdown-preview-code-background-color;
-    background-clip: padding-box;
-  }
-
-  atom-text-editor::shadow {
-    .line.cursor-line {
-      background-color: transparent;
-    }
-  }
-}
-
-
-
 // Timecop ---------------------------
 
 .timecop {

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -134,9 +134,6 @@
 
   .tab.active {
     color: @tab-text-color-active;
-    &[data-type$="Editor"] {
-      color: @tab-text-color-editor;
-    }
   }
 
   // Tab seperator ----------------------
@@ -253,22 +250,15 @@ atom-pane.active .tab.active:before {
 // Custom tabs --------------
 
 .tab-bar .tab.active {
-  &[data-type$="Editor"] {
+  &[data-type$="Editor"],
+  &[data-type="MarkdownPreviewView"] {
+    color: @tab-text-color-editor;
     background-color: @tab-background-color-editor;
     &::after {
       border-bottom-color: @tab-background-color-editor;
     }
     .title {
       background-color: @tab-background-color-editor;
-    }
-  }
-  &[data-type="MarkdownPreviewView"] {
-    background-color: @markdown-preview-background-color;
-    &::after {
-      border-bottom-color: @markdown-preview-background-color;
-    }
-    .title {
-      background-color: @markdown-preview-background-color;
     }
   }
 }

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -203,13 +203,6 @@
 @theme-config-box-shadow-selected: inset 0 1px 3px hsla(0, 0%, 0%, .2);
 @theme-config-border-selected: hsla(0, 0%, 0%, .5);
 
-@markdown-preview-color: @text-color;
-@markdown-preview-background-color: lighten(@base-background-color, 3%);
-@markdown-preview-hr-color: darken(@base-background-color, 10%);
-@markdown-preview-code-color: lighten(@text-color, 10%);
-@markdown-preview-code-background-color: darken(@base-background-color, 1%);
-
-
 
 // Debug
 // Output variables to the top of the UI


### PR DESCRIPTION
The Markdown Preview package will adapt to themes. See PR https://github.com/atom/markdown-preview/pull/298

So no more overriding is needed here. :sparkles: 