### PR TITLE
Center icons in buttons

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -90,7 +90,7 @@
 }
 
 
-// Button Group -----------------------
+// Button Sizes -----------------------
 
 .btn.btn-xs,
 .btn-group-xs > .btn {
@@ -159,4 +159,12 @@
   &.selected + .btn {
     border-left-color: @button-border-color-selected;
   }
+}
+
+
+// Button Icons -----------------------
+
+.btn.icon:before {
+  line-height: inherit;
+  vertical-align: top;
 }


### PR DESCRIPTION
:warning:  This depends on this PR in core: https://github.com/atom/atom/pull/9480

This PR centers the icons in buttons. Fixes https://github.com/atom/one-dark-ui/issues/103