### PR TITLE
Allow natural `left` for focus bar

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -67,7 +67,7 @@
   pointer-events: none;
   z-index: 1;
   top: @ui-padding-pane;
-  left: 0;
+  margin-left: -@component-icon-padding;
   height: @ui-tab-height;
   bottom: 0;
   width: 2px;


### PR DESCRIPTION
Allow natural `left` position and use a negative left margin to move the
focus bar relative to its container. This ensures the bar stays inside
its container in case the container is not leftmost in the Atom layout.

Fixes #41