### PR TITLE
Keep tree-view marker relative positioned

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -86,7 +86,7 @@ html { font-size: @font-size; }
   }
 
   .tree-view::before {
-    top: 0;
+    margin-top: 0;
   }
 
   .tree-view .project-root.project-root {

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -66,20 +66,14 @@
   position: fixed;
   pointer-events: none;
   z-index: 1;
-  top: @ui-padding-pane;
+  margin-top: @ui-padding-pane;
   margin-left: -@component-icon-padding;
   height: @ui-tab-height;
-  bottom: 0;
   width: 2px;
   background: @base-accent-color;
   opacity: 0;
   transform: scaleY(0);
   transition: opacity .16s, transform .16s cubic-bezier(.80, 0, .90, .53);
-}
-
-[data-show-on-right-side="true"] .tree-view::before {
-  left: auto;
-  right: 0;
 }
 
 .tree-view:focus::before {


### PR DESCRIPTION
... so that it doesn't overlap with anything added to the top.

Fixes point `2` of https://github.com/atom/atom/pull/9274#issuecomment-162856053