### PR TITLE
Remove top border

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -15,15 +15,6 @@ atom-workspace {
 
 }
 
-.platform-darwin {
-	atom-workspace.theme-one-light-ui {
-	  border-top: 1px solid darken(@base-border-color, 20%);
-	}
-	&.is-blurred atom-workspace.theme-one-light-ui {
-	  border-top-color: @base-border-color;
-	}
-}
-
 
 // Scrollbars ------------------------------------
 


### PR DESCRIPTION
It's now part of the title bar.

Before:

<img width="1016" alt="screenshot 2016-03-18 11 19 34" src="https://cloud.githubusercontent.com/assets/901000/13873662/8e4eba02-ecfb-11e5-9646-610a69059081.png">

After:

<img width="993" alt="screenshot 2016-03-18 11 24 50" src="https://cloud.githubusercontent.com/assets/901000/13873743/2b5511ac-ecfc-11e5-80dc-c0b5e3af9f3f.png">

Fixes #53 