### PR TITLE
Add tree-view bottom border

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -85,6 +85,11 @@ html { font-size: @font-size; }
     border-left: 1px solid @base-border-color;
   }
 
+  .tree-view-scroller {
+    border-image: none;
+    border-bottom: 1px solid @base-border-color;
+  }
+
   .tree-view::before {
     margin-top: 0;
   }

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -33,6 +33,11 @@
   }
 }
 
+.tree-view-scroller {
+  border-width: 0 0 1px 0;
+  border-image: linear-gradient(to right, @tree-view-background-color @component-padding, @base-border-color @component-padding * 5) 0 0 1 0 stretch;
+}
+
 // Variable height, based on ems
 .list-group li:not(.list-nested-item),
 .list-tree li:not(.list-nested-item),


### PR DESCRIPTION
Now that the status-bar spans full-width, it's not clear where the tree-view ends. Closes #55 

### Before:

![screen shot 2016-03-22 at 3 21 39 pm](https://cloud.githubusercontent.com/assets/378023/13943684/e40543c8-f041-11e5-8547-cbfb988a3b6d.png)

### After:

"Compact" mode
![screen shot 2016-03-22 at 3 21 07 pm](https://cloud.githubusercontent.com/assets/378023/13943687/ee1f39fe-f041-11e5-9c3b-d6eed2abd21a.png)

"Spacious" mode
![screen shot 2016-03-22 at 3 20 39 pm](https://cloud.githubusercontent.com/assets/378023/13943692/f38cec88-f041-11e5-9096-07779fdcd966.png)


