### PR TITLE
Add config for tab sizing

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,12 +2,19 @@ root = document.documentElement
 
 module.exports =
   activate: (state) ->
-    atom.config.observe('one-light-ui.fontSize', setFontSize)
-    atom.config.observe('one-light-ui.layoutMode', setLayoutMode)
+    atom.config.observe 'one-light-ui.fontSize', (value) ->
+      setFontSize(value)
+
+    atom.config.observe 'one-light-ui.layoutMode', (value) ->
+      setLayoutMode(value)
+
+    atom.config.observe 'one-light-ui.tabSizing', (value) ->
+      setTabSizing(value)
 
   deactivate: ->
     unsetFontSize()
     unsetLayoutMode()
+    unsetTabSizing()
 
 # Font Size -----------------------
 setFontSize = (currentFontSize) ->
@@ -25,3 +32,10 @@ setLayoutMode = (layoutMode) ->
 
 unsetLayoutMode = ->
   root.removeAttribute('theme-one-light-ui-layoutmode')
+
+# Tab Sizing -----------------------
+setTabSizing = (tabSizing) ->
+  root.setAttribute('theme-one-light-ui-tabsizing', tabSizing.toLowerCase())
+
+unsetTabSizing = ->
+  root.removeAttribute('theme-one-light-ui-tabsizing')

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "adaptive",
     "ui"
   ],
-  "repository": "https://github.com/atom/one-light-ui.git",
   "license": "MIT",
+  "repository": "https://github.com/atom/one-light-ui",
   "main": "lib/main",
   "engines": {
     "atom": ">0.40.0"
@@ -38,6 +38,17 @@
         "Compact",
         "Auto",
         "Spacious"
+      ]
+    },
+    "tabSizing": {
+      "title": "Tab Sizing",
+      "description": "In minimum width mode the tabs will be as small as possible but in even width mode, all tabs will be the same size. In auto mode the tabs switch based on the window size.",
+      "type": "string",
+      "default": "Auto",
+      "enum": [
+        "Even",
+        "Auto",
+        "Minimum"
       ]
     }
   }

--- a/spec/theme-spec.coffee
+++ b/spec/theme-spec.coffee
@@ -17,3 +17,9 @@ describe "One Light UI theme", ->
 
     atom.config.set('one-light-ui.layoutMode', 'Spacious')
     expect(document.documentElement.getAttribute('theme-one-light-ui-layoutmode')).toBe 'spacious'
+
+  it "allows the tab sizing to be set via config", ->
+    expect(document.documentElement.getAttribute('theme-one-light-ui-tabsizing')).toBe 'auto'
+
+    atom.config.set('one-light-ui.tabSizing', 'Minimum')
+    expect(document.documentElement.getAttribute('theme-one-light-ui-tabsizing')).toBe 'minimum'

--- a/styles/config.less
+++ b/styles/config.less
@@ -77,21 +77,6 @@ html { font-size: @font-size; }
       border-right: none;
       box-shadow: inset 0 1px 1px hsla(0,0%,100,.06), 1px 0 0 @base-border-color;
     }
-
-    // auto-size tabs
-    .tab,
-    .tab.active {
-      flex: 0 0 auto;
-      min-width: @ui-tab-height;
-    }
-
-    .tab .title {
-      -webkit-mask: none;
-    }
-    .tab:hover .title {
-      -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
-      -webkit-mask-position: -@modified-icon-width 0;
-    }
   }
 
 
@@ -127,5 +112,36 @@ html { font-size: @font-size; }
 @media (max-width: 1280px), (max-height: 800px) {
   [@{theme-layoutmode}="auto"] {
     .compact-mode();
+  }
+}
+
+// Small tabs mode ----------------------------------------------
+
+@theme-tabsizing: ~'theme-@{ui-theme-name}-tabsizing';
+
+[@{theme-tabsizing}="minimum"] {
+  .minimum-width-tabs();
+}
+
+@media (max-width: 1280px), (max-height: 800px) {
+  [@{theme-tabsizing}="auto"] {
+    .minimum-width-tabs();
+  }
+}
+
+.minimum-width-tabs() {
+  // auto-size tabs
+  .tab,
+  .tab.active {
+    flex: 0 0 auto;
+    min-width: @ui-tab-height;
+  }
+
+  .tab .title {
+    -webkit-mask: none;
+  }
+  .tab:hover .title {
+    -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
+    -webkit-mask-position: -@modified-icon-width 0;
   }
 }


### PR DESCRIPTION
Same as for the dark theme: https://github.com/atom/one-dark-ui/pull/131

![tabs](https://cloud.githubusercontent.com/assets/378023/14195645/905689d2-f7f6-11e5-989d-531741cdc243.gif)