### PR TITLE
Add background to close-icon

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -137,21 +137,28 @@ html { font-size: @font-size; }
     min-width: @ui-tab-height;
   }
 
-  .tab .close-icon {
-    padding-left: .4em;
-    padding-right: .4em;
+  .tab .close-icon.close-icon.close-icon {
+    top: .875em;
+    right: .5em;
+    width: 1.25em;
+    height: 1.25em;
+    line-height: 1.25;
+  }
+
+  .tab .close-icon::before {
+    height: inherit;
+    vertical-align: middle;
   }
 
   .tab .title {
     -webkit-mask: none;
+    margin-left: 1.25em;
+    margin-right: 1.25em;
   }
+
+  .tab.modified .title,
   .tab:hover .title {
     -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
     -webkit-mask-position: -@modified-icon-width*.6 0;
-  }
-
-  .tab.modified .title {
-    -webkit-mask: linear-gradient( to left, hsla(0,0%,0%,0), hsla(0,0%,0%,1) 1em) no-repeat;
-    -webkit-mask-position: -@modified-icon-width*.4 0;
   }
 }

--- a/styles/config.less
+++ b/styles/config.less
@@ -138,16 +138,16 @@ html { font-size: @font-size; }
   }
 
   .tab .close-icon.close-icon.close-icon {
-    top: .875em;
-    right: .5em;
+    top: .86em; // should be .875em but that messes up the pixel snapping
+    right: .46em; // again some random number helps with pixel snapping of the width
     width: 1.25em;
     height: 1.25em;
     line-height: 1.25;
   }
-
   .tab .close-icon::before {
-    height: inherit;
-    vertical-align: middle;
+    width: 1.25em;
+    height: 1.25em;
+    line-height: 1.25;
   }
 
   .tab .title {

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -87,23 +87,27 @@
     // Close icon ----------------------
 
     .close-icon {
-      top: 0;
-      right: 0;
+      top: .75em;
+      right: .75em;
       z-index: 2;
-      padding: 0 @tab-padding/1.25;
-      height: @ui-tab-height;
-      line-height: @ui-tab-height;
+      width: 1.5em;
+      height: 1.5em;
+      line-height: 1.5;
       text-align: center;
+      border-radius: @component-border-radius;
       transform: scale(0);
       transition: transform .08s;
       &:hover {
-        opacity: .7;
+        color: @base-accent-text-on-bg-color;
+        background-color: @base-accent-color;
       }
       &:active {
-        opacity: .4;
+        background-color: fade(@base-accent-color, 50%);
       }
       &::before {
         font-size: inherit;
+        width: auto;
+        height: auto;
       }
     }
     &:hover .close-icon {
@@ -155,19 +159,20 @@
 
   // Modified ----------------------
   .tab.modified {
-    .close-icon {
-      color: @text-color-info;
-      border: none;
-      border-bottom: @tab-border-size solid transparent;
+    &:hover .close-icon {
+      color: @base-accent-text-color;
+      &:hover {
+        color: @base-accent-text-on-bg-color;
+      }
     }
     &:not(:hover) .close-icon {
-      right: 0;
-      top: 0;
-      width: initial;
-      height: @ui-tab-height;
+      top: .75em;
+      right: .75em;
+      width: 1.5em;
+      height: 1.5em;
+      line-height: 1.5;
+      color: @base-accent-text-color;
       border: none;
-      border-bottom: @tab-border-size solid transparent;
-      border-radius: 0;
       transform: scale(1);
       &::before {
         content: "\f052";

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -87,14 +87,15 @@
     // Close icon ----------------------
 
     .close-icon {
-      top: .75em;
-      right: .75em;
+      top: .77em; // shoule be .75em but that messes up the pixel snapping
+      right: .77em;
       z-index: 2;
+      font-size: 1em;
       width: 1.5em;
       height: 1.5em;
       line-height: 1.5;
-      text-align: center;
       border-radius: @component-border-radius;
+      overflow: hidden;
       transform: scale(0);
       transition: transform .08s;
       &:hover {
@@ -105,9 +106,17 @@
         background-color: fade(@base-accent-color, 50%);
       }
       &::before {
-        font-size: inherit;
-        width: auto;
-        height: auto;
+        content: "\f05d"; // plus icon has a smaller weight
+        position: absolute;
+        font-size: 4em; // blow it up
+        width: 1.5em; // same as parent
+        height: 1.5em; // same as parent
+        line-height: 1.5; // same as parent
+        text-align: center;
+        transform: translate(-37.5%, -37.5%) // center: - (1.5 / 4)
+                   rotate(45deg) // rotate (since it's the "+" icon)
+                   scale(.33)  ; // scale it down again
+        pointer-events: none;
       }
     }
     &:hover .close-icon {

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -144,6 +144,10 @@
 // Base (Custom) -----------------
 @base-accent-color: hsl(@ui-hue, 64%, 56%);
 
+// Base Accent (Custom) -----------------
+@base-accent-color:            hsl(@ui-hue, 64%, 56%);
+@base-accent-text-color:       darken(@base-accent-color, 3%); // A bit darker when used for smaller things
+@base-accent-text-on-bg-color: contrast(@base-accent-color, white, hsl(@ui-hue,100%,12%), 33% );
 
 // Components (Custom) -----------------
 @badge-background-color:            fadein(@background-color-highlight, 8%);


### PR DESCRIPTION
Same as for dark https://github.com/atom/one-dark-ui/pull/144

Before :heavy_multiplication_x: | After :negative_squared_cross_mark:
--- | ---
![screen shot 2016-06-22 at 2 37 15 pm](https://cloud.githubusercontent.com/assets/378023/16255692/fa8ac9e6-3886-11e6-9e8d-1ef762864ed3.png) | ![screen shot 2016-06-22 at 2 36 48 pm](https://cloud.githubusercontent.com/assets/378023/16255695/00fe1d28-3887-11e6-9d23-ad8dc3442fed.png)
