### PR TITLE
Accent color

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -34,7 +34,7 @@
 }
 
 .btn-variant (@color) {
-  @_text-color: contrast(@color, hsl(0,0%,25%), white, 70% );
+  @_text-color: contrast(@color, white, hsl(0,0%,20%), 33% );
   .btn-default(
     @color,
     lighten(@color, 3%),

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -74,7 +74,7 @@
 }
 
 .btn.btn-primary {
-  .btn-variant(@base-accent-color);
+  .btn-variant(@accent-color);
 }
 .btn.btn-info {
   .btn-variant(@background-color-info);

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -23,7 +23,7 @@ atom-text-editor[mini] {
       background-color: @input-selection-color;
     }
     .cursor {
-      border-color: @base-accent-color;
+      border-color: @accent-color;
       border-width: 2px;
     }
   }

--- a/styles/progress.less
+++ b/styles/progress.less
@@ -9,7 +9,7 @@
   width: 1em;
   height: 1em;
   font-size: @size;
-  background: radial-gradient(@base-accent-color .1em, transparent .11em);
+  background: radial-gradient(@accent-color .1em, transparent .11em);
 
   &::before,
   &::after {
@@ -27,10 +27,10 @@
     -webkit-animation-fill-mode: backwards;
   }
   &::before {
-    border-color: @base-accent-color transparent transparent transparent;
+    border-color: @accent-color transparent transparent transparent;
   }
   &::after {
-    border-color: transparent lighten(@base-accent-color, 15%) transparent transparent;
+    border-color: transparent lighten(@accent-color, 15%) transparent transparent;
     -webkit-animation-delay: @spinner-duration/2;
   }
 

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -117,6 +117,10 @@
 		font-size: .75em;
 	}
 
+	.install-button {
+		.btn-variant(@accent-color);
+	}
+
 	.search-container .btn {
 		font-size: @ui-input-size;
 	}

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -121,6 +121,18 @@
 		.btn-variant(@accent-color);
 	}
 
+	input[type="checkbox"] {
+		background-color: @background-color-selected;
+		&:active,
+		&:checked {
+			background-color: @accent-color;
+		}
+		&:before,
+		&:after {
+			background-color: @accent-text-on-bg-color;
+		}
+	}
+
 	.search-container .btn {
 		font-size: @ui-input-size;
 	}

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -99,11 +99,11 @@
       transform: scale(0);
       transition: transform .08s;
       &:hover {
-        color: @base-accent-text-on-bg-color;
-        background-color: @base-accent-color;
+        color: @accent-text-on-bg-color;
+        background-color: @accent-color;
       }
       &:active {
-        background-color: fade(@base-accent-color, 50%);
+        background-color: fade(@accent-color, 50%);
       }
       &::before {
         content: "\f05d"; // plus icon has a smaller weight
@@ -169,9 +169,9 @@
   // Modified ----------------------
   .tab.modified {
     &:hover .close-icon {
-      color: @base-accent-text-color;
+      color: @accent-text-color;
       &:hover {
-        color: @base-accent-text-on-bg-color;
+        color: @accent-text-on-bg-color;
       }
     }
     &:not(:hover) .close-icon {
@@ -180,7 +180,7 @@
       width: 1.5em;
       height: 1.5em;
       line-height: 1.5;
-      color: @base-accent-text-color;
+      color: @accent-text-color;
       border: none;
       transform: scale(1);
       &::before {
@@ -204,7 +204,7 @@
   .placeholder {
     margin: 0;
     height: @ui-tab-height;
-    background: @base-accent-color;
+    background: @accent-color;
     pointer-events: none;
     &:after {
       top: @ui-tab-height/2;
@@ -213,7 +213,7 @@
       margin: -5px 0 0 0;
       border-radius: 0;
       border: 5px solid;
-      border-color: transparent transparent transparent @base-accent-color;
+      border-color: transparent transparent transparent @accent-color;
       background: transparent;
     }
 
@@ -222,7 +222,7 @@
 
       &:after {
         margin-left: -10px;
-        border-color: transparent @base-accent-color transparent transparent;
+        border-color: transparent @accent-color transparent transparent;
       }
     }
   }
@@ -242,7 +242,7 @@
   width: 2px;
   border-top-left-radius: inherit;
   border-radius: @component-border-radius 0;
-  background: @base-accent-color;
+  background: @accent-color;
   opacity: 0;
   transition: opacity .16s;
 

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -75,7 +75,7 @@
   margin-left: -@component-icon-padding;
   height: @ui-tab-height;
   width: 2px;
-  background: @base-accent-color;
+  background: @accent-color;
   opacity: 0;
   transition: opacity .16s;
 }

--- a/styles/ui-mixins.less
+++ b/styles/ui-mixins.less
@@ -32,6 +32,6 @@
 
 .focus() {
   outline: none;
-  border-color: @base-accent-color;
-  box-shadow: 0 0 0 1px @base-accent-color;
+  border-color: @accent-color;
+  box-shadow: 0 0 0 1px @accent-color;
 }

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -46,20 +46,20 @@
 
 
 // Base (Custom) -----------------
-@base-accent-color: hsl(@ui-hue, 64%, 56%);
+@accent-color: hsl(@ui-hue, 64%, 56%);
 
 // Base Accent (Custom) -----------------
-@base-accent-color:            hsl(@ui-hue, 64%, 56%);
-@base-accent-text-color:       darken(@base-accent-color, 3%); // A bit darker when used for smaller things
-@base-accent-text-on-bg-color: contrast(@base-accent-color, white, hsl(@ui-hue,100%,12%), 33% );
+@accent-color:            hsl(@ui-hue, 64%, 56%);
+@accent-text-color:       darken(@accent-color, 3%); // A bit darker when used for smaller things
+@accent-text-on-bg-color: contrast(@accent-color, white, hsl(@ui-hue,100%,12%), 33% );
 
 // Components (Custom) -----------------
 @badge-background-color:            fadein(@background-color-highlight, 8%);
 
 @button-text-color-selected:        contrast(@button-background-color-selected, hsl(@ui-hue,100%,100%), hsl(@ui-hue,100%,12%), 40% );
-@button-border-color-selected:      @base-accent-color;
+@button-border-color-selected:      @accent-color;
 
-@checkbox-background-color:         fade(@base-accent-color, 33%);
+@checkbox-background-color:         fade(@accent-color, 33%);
 
 @input-background-color-focus:      hsl(@ui-hue, 100%, 96%);
 @input-selection-color:             @background-color-selected;
@@ -70,7 +70,7 @@
 
 @overlay-backdrop-color:            hsla(@ui-hue,@ui-saturation,5%,.5);
 
-@progress-background-color:         @base-accent-color;
+@progress-background-color:         @accent-color;
 
 @scrollbar-color:                   darken(@level-3-color, 14%);
 @scrollbar-background-color:        @level-3-color; // replaced `transparent` with a solid color to test https://github.com/atom/one-light-ui/issues/4
@@ -82,7 +82,7 @@
 @tab-text-color-editor:             contrast(@ui-syntax-color, lighten(@ui-syntax-color, 70%), @text-color-highlight );
 @tab-background-color-editor:       @ui-syntax-color;
 
-@tooltip-background-color:          @base-accent-color;
+@tooltip-background-color:          @accent-color;
 @tooltip-text-color:                contrast(@tooltip-background-color, hsl(@ui-hue,100%,100%), hsl(@ui-hue,100%,12%), 40% );
 @tooltip-text-key-color:            @tooltip-background-color;
 @tooltip-background-key-color:      @tooltip-text-color;

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -53,7 +53,7 @@
 // Components (Custom) -----------------
 @badge-background-color:            fadein(@background-color-highlight, 8%);
 
-@button-text-color-selected:        contrast(@button-background-color-selected, hsl(@ui-hue,100%,100%), hsl(@ui-hue,100%,12%), 40% );
+@button-text-color-selected:        @accent-text-on-bg-color;
 @button-border-color-selected:      @accent-color;
 
 @checkbox-background-color:         fade(@accent-color, 33%);

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -45,10 +45,7 @@
 @level-3-color: darken(@base-background-color, 8%);
 
 
-// Base (Custom) -----------------
-@accent-color: hsl(@ui-hue, 64%, 56%);
-
-// Base Accent (Custom) -----------------
+// Accent (Custom) -----------------
 @accent-color:            hsl(@ui-hue, 64%, 56%);
 @accent-text-color:       darken(@accent-color, 3%); // A bit darker when used for smaller things
 @accent-text-on-bg-color: contrast(@accent-color, white, hsl(@ui-hue,100%,12%), 33% );
@@ -83,7 +80,7 @@
 @tab-background-color-editor:       @ui-syntax-color;
 
 @tooltip-background-color:          @accent-color;
-@tooltip-text-color:                contrast(@tooltip-background-color, hsl(@ui-hue,100%,100%), hsl(@ui-hue,100%,12%), 40% );
+@tooltip-text-color:                @accent-text-on-bg-color;
 @tooltip-text-key-color:            @tooltip-background-color;
 @tooltip-background-key-color:      @tooltip-text-color;
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -60,7 +60,7 @@
 
 @button-background-color:          @level-1-color;
 @button-background-color-hover:    darken(@button-background-color, 4%);
-@button-background-color-selected: lighten(@base-accent-color, 4%);
+@button-background-color-selected: lighten(@accent-color, 4%);
 @button-border-color:              @base-border-color;
 
 @tab-bar-background-color:         @level-3-color;


### PR DESCRIPTION
Same as https://github.com/atom/one-dark-ui/pull/147

This refactors some styles around the "accent color".

Additionally, the accent color gets also used for:

- For the install button in the settings. So it matches the "Update all" button.
- The checkboxes

#### Before
![screen shot 2016-06-24 at 11 54 35 am](https://cloud.githubusercontent.com/assets/378023/16326536/7cccc7d4-3a02-11e6-856e-e384032dbc36.png)

#### After
![screen shot 2016-06-24 at 11 54 10 am](https://cloud.githubusercontent.com/assets/378023/16326538/829bd9ca-3a02-11e6-8d37-6290d5f10cb4.png)
![screen shot 2016-06-24 at 11 57 14 am](https://cloud.githubusercontent.com/assets/378023/16326574/e1b0addc-3a02-11e6-9b4d-66446f820928.png)
![screen shot 2016-06-24 at 11 57 35 am](https://cloud.githubusercontent.com/assets/378023/16326575/e1b212e4-3a02-11e6-9b73-ff323a236512.png)
