### PR TITLE
Reduce Auto breakpoints

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -1,3 +1,9 @@
+// Variables
+
+@auto-breakpoint-width: 1000px;
+@auto-breakpoint-height: 600px;
+
+
 // Compact mode ----------------------------------------------
 
 @theme-layoutmode: ~'theme-@{ui-theme-name}-layoutmode';
@@ -109,7 +115,7 @@ html { font-size: @font-size; }
   .compact-mode();
 }
 
-@media (max-width: 1280px), (max-height: 800px) {
+@media (max-width: @auto-breakpoint-width), (max-height: @auto-breakpoint-height) {
   [@{theme-layoutmode}="auto"] {
     .compact-mode();
   }
@@ -123,7 +129,7 @@ html { font-size: @font-size; }
   .minimum-width-tabs();
 }
 
-@media (max-width: 1280px), (max-height: 800px) {
+@media (max-width: @auto-breakpoint-width) {
   [@{theme-tabsizing}="auto"] {
     .minimum-width-tabs();
   }


### PR DESCRIPTION
This makes the "Auto mode" breakpoint a bit smaller. From `1280x800` to `1000x600`.

So in "Auto mode", if the window is:

Smaller or `1000x600` | Larger than `1000x600`
--- | ---
Compact layout | Spacious layout
Minimal tabs | Even tabs

Ref https://github.com/atom/one-dark-ui/issues/149