### PR TITLE
List group: maintain consistent size regardless of active icon presence

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -84,6 +84,7 @@
       left: auto; right: auto;
       height: @active-icon-size;
       width: @active-icon-size;
+      font-size: @active-icon-size;
     }
     > li:not(.active):before {
       margin-right: @ui-padding-icon;


### PR DESCRIPTION
Because the margin is defined in terms of em, we need to make sure that the font-size is the same regardless of whether the icon is being displayed. Otherwise, the calculated margin will change.

Before:

![before](https://cloud.githubusercontent.com/assets/126263/18494388/b51491dc-79ca-11e6-919d-f41343af0c57.gif)

After:

![after](https://cloud.githubusercontent.com/assets/126263/18494393/ba09fd26-79ca-11e6-85bd-bd3896632426.gif)
