### PR TITLE
Add max height to mini editors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,10 +1,8 @@
 atom-text-editor[mini] {
-  line-height: @component-line-height;
-  max-height: @component-line-height + 2; // +2 for borders
   overflow: auto;
   font-size: @ui-input-size;
   line-height: @ui-line-height;
-  max-height: none;
+  max-height: @ui-line-height * 5; // rows
   padding-left: @ui-padding/3;
   border-radius: @component-border-radius;
   color: @text-color-highlight;


### PR DESCRIPTION
So they don't grow too large. Currently limited at 5 rows:

![screen shot 2016-10-20 at 7 26 55 pm](https://cloud.githubusercontent.com/assets/378023/19556283/597ebeee-96fb-11e6-8a36-651285289364.png)

Closes https://github.com/atom/one-dark-ui/issues/166