### PR TITLE
Colorize character matches in the command palette

### DIFF
--- a/styles/key-binding.less
+++ b/styles/key-binding.less
@@ -7,6 +7,6 @@
   font-size: max(1em, @ui-size*.85);
   letter-spacing: @ui-size/10;
   border-radius: @component-border-radius;
-  border: 1px solid @key-binding-border-color;
-  background-color: @key-binding-background-color;
+  color: @accent-bg-text-color;
+  background-color: @accent-bg-color;
 }

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -134,6 +134,15 @@
   }
 }
 
+
+// Command Palette + Fuzzy Finder ---------------------------
+
+.command-palette .list-group .character-match,
+.fuzzy-finder .list-group .character-match {
+  color: @accent-color;
+}
+
+
 // Deprecation Cop ---------------------------
 
 .deprecation-cop {

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -139,7 +139,7 @@
 
 .command-palette .list-group .character-match,
 .fuzzy-finder .list-group .character-match {
-  color: @accent-color;
+  color: @accent-only-text-color;
 }
 
 

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -72,9 +72,6 @@
 @input-selection-color:             mix( hsv( @ui-hue, 33%, 95%), hsl( @ui-hue, 100%, 98%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 @input-selection-color-focus:       mix( hsv( @ui-hue, 44%, 90%), hsl( @ui-hue, 100%, 94%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 
-@key-binding-border-color:          @base-border-color;
-@key-binding-background-color:      @level-2-color;
-
 @overlay-backdrop-color:            hsl(@ui-hue, @ui-saturation*0.4, @ui-lightness*0.72);
 @overlay-backdrop-opacity:          .8;
 

--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -56,6 +56,9 @@
 @accent-bg-color:         mix( hsv( @ui-hue, 40%, 72%), hsl( @ui-hue, 100%, 66%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 @accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 40% );
 
+// used for text only
+@accent-only-text-color: mix( hsv( @ui-hue, 70%, 50%), hsl( @ui-hue, 100%, 60%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
+
 
 // Components (Custom) -----------------
 @badge-background-color:            @background-color-selected;


### PR DESCRIPTION
### Before

Only happened when switching themes, see https://github.com/atom/one-light-ui/issues/70#issuecomment-261812610.

![atom hl](https://cloud.githubusercontent.com/assets/48756/18084886/295a0644-6ea9-11e6-8fdd-a42a5234f45a.png)

### After

![screen shot 2016-11-22 at 6 53 09 pm](https://cloud.githubusercontent.com/assets/378023/20519292/ad90f0f2-b0e5-11e6-9531-5556b51a8f70.png)

Fixes https://github.com/atom/one-light-ui/issues/70