### PR TITLE
Tweak selection color

### DIFF
--- a/styles/ui-variables-custom.less
+++ b/styles/ui-variables-custom.less
@@ -19,7 +19,7 @@
 // Main colors -----------------
 @ui-fg:     hsl(@ui-hue, @ui-saturation, @ui-lightness - 72%);
 @ui-bg:     hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
-@ui-border: darken(@base-background-color, 16%);
+@ui-border: darken(@level-3-color, 6%);
 
 
 
@@ -43,7 +43,7 @@
 // Background (Custom) -----------------
 @level-1-color: lighten(@base-background-color, 4%);
 @level-2-color: @base-background-color;
-@level-3-color: darken(@base-background-color, 8%);
+@level-3-color: darken(@base-background-color, 6%);
 
 
 // Accent (Custom) -----------------
@@ -88,7 +88,7 @@
 @tab-text-color-editor:             contrast(@ui-syntax-color, lighten(@ui-syntax-color, 70%), @text-color-highlight );
 @tab-background-color-editor:       @ui-syntax-color;
 
-@tree-view-background-selected-color: darken(@level-3-color, 5%);
+@tree-view-background-selected-color: @background-color-selected;
 
 @tooltip-background-color:          @accent-bg-color;
 @tooltip-text-color:                @accent-bg-text-color;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -12,9 +12,9 @@
 
 // Text -----------------
 @text-color:            @ui-fg;
-@text-color-subtle:     lighten(@text-color, 32%);
-@text-color-highlight:  darken(@text-color, 10%);
-@text-color-selected:   darken(@text-color-highlight, 10%);
+@text-color-subtle:     lighten(@text-color, 30%);
+@text-color-highlight:  darken(@text-color, 12%);
+@text-color-selected:   darken(@text-color-highlight, 12%);
 
 @text-color-info:    hsl(208, 100%, 54%);
 @text-color-success: hsl(132,  60%, 44%);
@@ -28,8 +28,8 @@
 @background-color-warning: hsl( 40,  60%, 48%);
 @background-color-error:   hsl(  5,  72%, 56%);
 
-@background-color-highlight: darken(@base-background-color, 4%);
-@background-color-selected:  darken(@base-background-color, 6%);
+@background-color-highlight: darken(@level-3-color, 2%);
+@background-color-selected:  darken(@level-3-color, 6%);
 
 @app-background-color: @level-3-color;
 


### PR DESCRIPTION
### Description of the Change

This tweaks some colors, mostly around selections. Because there is just a single `@background-color-selected` variable for selections it's hard to know on which background it's used. This PR makes sure the selection is darker than the darkest used background.

Before | After
--- | ---
![screen shot 2017-03-03 at 11 58 20 pm](https://cloud.githubusercontent.com/assets/378023/23555725/5630c0b2-006d-11e7-88a2-1956f85e3fc9.png) | ![screen shot 2017-03-03 at 11 57 54 pm](https://cloud.githubusercontent.com/assets/378023/23555730/5dd57b5a-006d-11e7-82a4-205650fa1741.png)


### Alternate Designs

Selections could also be lighter than the background, but then it's too close to buttons, inputs etc.

### Benefits

Makes selections easier to see.

### Possible Drawbacks

Packages might are used to the current colors.

