### PR TITLE
Style tabs in docks differently

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -197,6 +197,19 @@
     }
   }
 
+  // Tabs in the docks ----------------------
+
+  atom-dock & {
+    .tab.active {
+      background-color: @tool-panel-background-color;
+      &::after {
+        border-bottom-color: @tool-panel-background-color;
+      }
+      .title {
+        background-color: @tool-panel-background-color;
+      }
+    }
+  }
 
   // Dragging ----------------------
 


### PR DESCRIPTION
This is a small update that goes along with atom/atom#13977 and changes the color of the active tab.