### PR TITLE
Make sure [data-path] element receives mouse events

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -59,6 +59,10 @@
       box-shadow: inset 0 1px 1px hsla(0,0%,100,.06);
       transition: opacity .16s;
       opacity: 0;
+
+      // Make sure that the :after pseudoelement doesn't get the click instead
+      // of the element with the [data-path] attribute.
+      pointer-events: none;
     }
     &.active::after {
       opacity: 1;


### PR DESCRIPTION
This makes sure the the element with the `data-path` attribute receives mouse events (instead of the pseudo-element), allowing us to target `[data-path]` in context menu items.

The corresponding PR for the dark theme is atom/one-dark-ui#195