### PR TITLE
Improve focus

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -11,11 +11,6 @@
   background-color: @color;
   background-image: linear-gradient(lighten(@color, 2%), @color);
 
-  &:focus {
-    //.focus(); // disabled for now, since :focus styles stay even after releasing mouse.
-    outline: none;
-  }
-  &:focus,
   &:hover {
     color: @text-color-highlight;
     background-image: linear-gradient(lighten(@hover-color, 2%), @hover-color);
@@ -30,6 +25,9 @@
   &.selected:focus,
   &.selected:hover {
     background: lighten(@selected-color, 2%);
+  }
+  &:focus {
+    .focus(); // unfortunately :focus styles stay even after releasing mouse.
   }
 }
 
@@ -50,6 +48,10 @@
   &:hover,
   &:focus {
     color: @_text-color;
+  }
+  &:focus {
+    border-color: transparent;
+    box-shadow: inset 0 0 0 1px fade(@_text-color, 50%), 0 0 0 1px @color;
   }
 
   &.icon:before {
@@ -148,6 +150,9 @@
   &.btn:focus {
     z-index: 1;
   }
+  &:focus {
+    .focus();
+  }
 
   &.selected,
   &.selected:first-child,
@@ -158,6 +163,10 @@
   &.selected + .btn {
     border-left-color: @button-border-color-selected;
   }
+  &.selected:focus {
+    box-shadow: inset 0 0 0 1px fade(@button-text-color-selected, 50%), 0 0 0 1px @button-border-color-selected;
+  }
+
 }
 
 

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -51,7 +51,8 @@
   }
   &:focus {
     border-color: transparent;
-    box-shadow: inset 0 0 0 1px fade(@_text-color, 50%), 0 0 0 1px @color;
+    background-clip: padding-box;
+    box-shadow: inset 0 0 0 1px fade(@base-border-color, 50%), 0 0 0 1px @color;
   }
 
   &.icon:before {
@@ -120,11 +121,16 @@
   &:hover {
     z-index: 0;
   }
+  &.btn:focus {
+    z-index: 1;
+    .focus();
+  }
 
   &:first-child {
     border-left: @btn-border;
   }
-  &:last-child {
+  &:last-child,
+  &.selected:last-child {
     border-right: @btn-border;
   }
 
@@ -147,26 +153,26 @@
     }
   }
 
-  &.btn:focus {
-    z-index: 1;
-  }
-  &:focus {
-    .focus();
-  }
-
   &.selected,
   &.selected:first-child,
   &.selected:last-child {
     color: @button-text-color-selected;
-    border: 1px solid @button-border-color-selected;
-  }
-  &.selected + .btn {
-    border-left-color: @button-border-color-selected;
-  }
-  &.selected:focus {
-    box-shadow: inset 0 0 0 1px fade(@button-text-color-selected, 50%), 0 0 0 1px @button-border-color-selected;
+    border-color: @button-border-color-selected;
   }
 
+  & when (@ui-lightness > 50%) {
+    &.selected + .btn {
+      border-left-color: @button-border-color-selected;
+    }
+    &.selected + .selected {
+      border-left-color: mix(@button-border-color, @button-border-color-selected);
+    }
+  }
+
+  &.selected:focus {
+    border-color: @button-background-color-selected;
+    box-shadow: inset 0 0 0 1px fade(@base-border-color, 50%), 0 0 0 1px @button-background-color-selected;
+  }
 }
 
 

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,3 +1,14 @@
+
+// Editor in a panel
+
+atom-panel-container atom-text-editor.is-focused {
+  .focus();
+}
+
+
+// Mini
+// Usually just single line inputs
+
 atom-text-editor[mini] {
   overflow: auto;
   font-size: @ui-input-size;
@@ -12,9 +23,11 @@ atom-text-editor[mini] {
   .placeholder-text {
     color: @text-color-subtle;
   }
+
   .selection .region {
     background-color: @input-selection-color;
   }
+
   .cursor {
     border-color: @accent-color;
     border-width: 2px;

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -1,4 +1,17 @@
 
+
+//
+// Text
+// -------------------------
+
+.input-text,
+.input-search,
+.input-textarea {
+  &:focus {
+    .focus();
+  }
+}
+
 //
 // Checkbox
 // -------------------------

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -1,17 +1,4 @@
 
-
-//
-// Text
-// -------------------------
-
-.input-text,
-.input-search,
-.input-textarea {
-  &:focus {
-    .focus();
-  }
-}
-
 //
 // Checkbox
 // -------------------------
@@ -72,5 +59,20 @@
   }
   &:before {
     background-color: @accent-text-color;
+  }
+}
+
+
+
+// States -------------------------
+
+.input-text,
+.input-search,
+.input-number,
+.input-textarea,
+.input-select,
+.input-color {
+  &:focus {
+    .focus();
   }
 }


### PR DESCRIPTION
### Description of the Change

This adds focus styles to various inputs and buttons.

![focus-text](https://cloud.githubusercontent.com/assets/378023/24070236/95d52880-0bfc-11e7-901a-31d77a08fdd7.gif)
![focus-buttons](https://cloud.githubusercontent.com/assets/378023/24070237/95d71a1e-0bfc-11e7-8d0f-9d3d86434c88.gif)


### Alternate Designs

None, really since there is already a focus style for mini editors. Still not sure if/how to focus radios or checkboxes.

### Benefits

Easier to see where the focus is when moving around with the keyboard.

### Possible Drawbacks

Unfortunately the `:focus` styles stay when clicking with the mouse on a button until you move the focus away. In some situations it can look too obtrusive having the blue border stick around.

- We might could add some sort of "focused with the keyboard only" class when tabbing to a button. Not sure how easy that would be.
- One day there hopefully will be something like a `:focus-ring` selector, proposal 👉  https://github.com/WICG/focus-ring

### Applicable issues

Closes #93