### PR TITLE
Add maximum tab option

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,12 @@
     },
     "tabSizing": {
       "title": "Tab Sizing",
-      "description": "In Even mode all tabs will be the same size. Great for quickly closing many tabs. In Minimum mode the tabs will only take as little space as needed and also show longer file names.",
+      "description": "In Even mode all tabs will be the same size. Great for quickly closing many tabs. In Maximum mode the tabs will expand to take up the full width. In Minimum mode the tabs will only take as little space as needed and also show longer file names.",
       "type": "string",
       "default": "Even",
       "enum": [
         "Even",
+        "Maximum",
         "Minimum"
       ],
       "order": 2

--- a/spec/theme-spec.coffee
+++ b/spec/theme-spec.coffee
@@ -13,6 +13,10 @@ describe "One Light UI theme", ->
     expect(document.documentElement.style.fontSize).toBe ''
 
   it "allows the tab sizing to be set via config", ->
+    atom.config.set('one-light-ui.tabSizing', 'Maximum')
+    expect(document.documentElement.getAttribute('theme-one-light-ui-tabsizing')).toBe 'maximum'
+
+  it "allows the tab sizing to be set via config", ->
     atom.config.set('one-light-ui.tabSizing', 'Minimum')
     expect(document.documentElement.getAttribute('theme-one-light-ui-tabsizing')).toBe 'minimum'
 

--- a/styles/config.less
+++ b/styles/config.less
@@ -13,8 +13,14 @@
   .tab,
   .tab.active {
     flex: 1 1 0;
-    max-width: none;
+    max-width: 22em;
     min-width: @tab-min-width;
+  }
+  atom-dock & {
+    .tab,
+    .tab.active {
+      max-width: none;
+    }
   }
 
   // TODO: Turn this into a config
@@ -22,6 +28,16 @@
   // .title.title.title {
   //   direction: rtl; // change direction
   // }
+}
+
+
+// Maximum (full width) ---------------
+
+[@{theme-tabsizing}="maximum"] .tab-bar {
+  .tab,
+  .tab.active {
+    max-width: none;
+  }
 }
 
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -44,7 +44,7 @@
       box-shadow: none;
     }
     &:first-of-type {
-      border-left: none;
+      border-left-color: transparent;
     }
     &:last-of-type {
       // use box-shadow to not take up any space
@@ -181,25 +181,13 @@
       background: transparent;
     }
 
-    &:first-child {
-      position: absolute;
-      left: 0;
-
-      &:after {
-        transform: none;
-        margin-left: 2px;
-        border-color: transparent transparent transparent @accent-color;
-      }
-    }
-
-    // revert direction when last child
     &:last-child {
-      position: absolute;
-      right: 2px;
-
+      &:before {
+        margin-left: -2px;
+      }
       &:after {
         transform: none;
-        margin-left: -8px;
+        margin-left: -10px;
         border-color: transparent @accent-color transparent transparent;
       }
     }


### PR DESCRIPTION
### Description of the Change

- Makes the tabs have a maximum width by default (like it used to be). Tabs in docks stay full width.
- Adds a "Maximum" option to make (center) tabs expand to full width.

![tabs](https://cloud.githubusercontent.com/assets/378023/24890369/78e43c78-1eaa-11e7-8cab-6845c1484dc5.gif)

### Alternate Designs

This _is_ an alternative to #96.

### Benefits

The change in #96 won't be as drastic, but still give people the option go full width if they like.

### Possible Drawbacks

None (apart from maintaining another option).

### Applicable Issues

Came up in Slack, part of #96.
