### PR TITLE
Adjust tab icon size

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -66,9 +66,11 @@
     // Icons ----------------------
 
     .title.title:before {
-      margin-right: .1em;
+      margin-right: .3em;
+      width: 1em;
+      height: 1em;
+      line-height: 1;
       font-size: 1.1em;
-      text-align: left;
     }
 
     // Close icon ----------------------


### PR DESCRIPTION
### Description of the Change

This makes the tab icons adjust better to UI font size changes.

Before:

<img width="357" alt="binarymuse_fluxxor_117_______src_react_fluxxor_720" src="https://cloud.githubusercontent.com/assets/378023/25061596/18e32110-21f5-11e7-8557-ac3b55405e56.png">

After:

![icons](https://cloud.githubusercontent.com/assets/378023/25300999/652b303c-2757-11e7-9e4d-db5976b8eba6.gif)

### Benefits

A happy @BinaryMuse 

### Possible Drawbacks

This might override icon packages.

### Applicable Issues

Closes https://github.com/atom/one-light-ui/issues/99
