### PR TITLE
Align icons

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -180,5 +180,4 @@
 
 .btn.icon:before {
   line-height: inherit;
-  vertical-align: top;
 }

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -179,5 +179,8 @@
 // Button Icons -----------------------
 
 .btn.icon:before {
-  line-height: inherit;
+  width: auto;
+  height: auto;
+  font-size: 1.333333em;
+  vertical-align: -.1em;
 }

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -43,12 +43,15 @@
       margin-left: 0; // override default
     }
   }
-
+  .icon {
+    vertical-align: middle;
+  }
   .icon::before {
-    font-size: 16px; // keeps them sharp
-  	width: auto;
-    height: 16px;
-    margin-right: 4px;
+    font-size: 1.33333em; // should be 16px with a default of 12px
+  	width: auto; // use natural width
+    height: auto;
+    margin-right: .25em;
+    top: auto;
   }
 }
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -83,6 +83,7 @@
       width: 1.5em;
       height: 1.5em;
       line-height: 1.5;
+      text-align: center;
       border-radius: @component-border-radius;
       background-color: inherit;
       overflow: hidden;
@@ -97,12 +98,10 @@
       }
       &::before {
         z-index: 1;
-        position: absolute;
         font-size: 1.1em;
-        width: inherit;
-        height: inherit;
-        line-height: inherit;
-        text-align: center;
+        vertical-align: -.05em; // Adjust center for the 0.1em font-size increase
+        width: auto;
+        height: auto;
         pointer-events: none;
       }
     }

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -67,10 +67,11 @@
 
     .title.title:before {
       margin-right: .3em;
-      width: 1em;
-      height: 1em;
+      width: auto;
+      height: auto;
       line-height: 1;
-      font-size: 1.1em;
+      font-size: 1.125em;
+      vertical-align: -.0625em; // Adjust center for the 0.1em font-size increase
     }
 
     // Close icon ----------------------


### PR DESCRIPTION
### Description of the Change

This fixes some alignments of icons. Not quite sure what caused the change, maybe related to updating Chromium?

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/378023/28854622-469feaf6-7773-11e7-988a-600e109f4eaf.png) | ![image](https://user-images.githubusercontent.com/378023/28854614-34bd84ba-7773-11e7-9bb8-0836c5b83236.png)

### Benefits

Icons should be aligned better.

### Possible Drawbacks

There could still be some places that got missed, but overall should be an improvement.

### Applicable Issues

Fixes https://github.com/atom/one-light-ui/issues/104
