### PR TITLE
Vertically center sync icon

### DIFF
--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -49,7 +49,8 @@
   .icon::before {
     font-size: 1.33333em; // should be 16px with a default of 12px
   	width: auto; // use natural width
-    height: auto;
+    line-height: 1;
+    height: 1em; // same as line-height
     margin-right: .25em;
     top: auto;
   }


### PR DESCRIPTION
### Description of the Change

This changes the height of status-bar icons to be the same as the font-size.

### Benefits

Less wiggling when rotating.

![sync](https://user-images.githubusercontent.com/378023/29737296-329055f6-8a46-11e7-94a9-d4cdf0fccde0.gif)

### Possible Drawbacks

Other possible side effects.

### Applicable Issues

Supersedes and closes https://github.com/atom/github/pull/1129
