### PR TITLE
Increase contrast of VCS colored and focused tree-view

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -21,8 +21,9 @@
 
   // Focus + selected state
   &:focus {
-    .selected.list-item > .name,
-    .selected.list-nested-item > .list-item > .name {
+    .selected.list-item > .name, // files
+    .selected.list-nested-item > .list-item > .name, // folders
+    .selected.list-nested-item > .header:before { // arrow icon
       color: contrast(@button-background-color-selected);
     }
     .selected:before {

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -14,13 +14,20 @@
     }
   }
 
+  // Selected state
   .selected:before {
     background: @background-color-selected;
   }
 
-  &:focus .selected:before {
-    color: contrast(@button-background-color-selected);
-    background: @button-background-color-selected;
+  // Focus + selected state
+  &:focus {
+    .selected.list-item > .name,
+    .selected.list-nested-item > .list-item > .name {
+      color: contrast(@button-background-color-selected);
+    }
+    .selected:before {
+      background: @button-background-color-selected;
+    }
   }
 }
 


### PR DESCRIPTION
### Description of the Change

This makes the text color of VCS colored + selected + focused tree-view items white.

Before | After
--- | ---
![screen shot 2017-12-09 at 5 06 17 pm](https://user-images.githubusercontent.com/378023/33793866-4fa387b6-dd03-11e7-8656-75b4b7207e5c.png) | ![screen shot 2017-12-09 at 5 05 57 pm](https://user-images.githubusercontent.com/378023/33793865-4f768e00-dd03-11e7-8338-b2bbc0a755f2.png)

### Benefits

Better contrast

### Possible Drawbacks

You can't see the VCS coloring while the tree-view is in focus. We could potentially add some colored dot/stripe. But maybe in a separate PR.

### Applicable Issues

Follow-up of https://github.com/atom/one-light-ui/pull/114#issuecomment-350065311
