### PR TITLE
Sticky projects

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -83,3 +83,35 @@
 .tree-view .project-root-header.project-root-header.project-root-header.project-root-header::before {
   line-height: @ui-tab-height;
 }
+
+
+// Sticky Projects ------------------------------
+
+.tree-view {
+  .project-root-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding-left: 5px;
+    padding-right: 10px;
+    border-bottom: 1px solid @base-border-color;
+    background-color: @tree-view-background-color;
+  }
+  .project-root.project-root {
+    margin-left: -5px;
+    margin-right: -10px;
+
+    // Disable selection
+    &::before {
+      display: none;
+    }
+
+    // Add selection back
+    &.selected .project-root-header {
+      background-color: @background-color-selected;
+    }
+  }
+  &:focus .selected .project-root-header.project-root-header  {
+    background: @button-background-color-selected;
+  }
+}


### PR DESCRIPTION
### Description of the Change

This makes the project root in the tree-view stick to the top when scrolling.

![sticky](https://user-images.githubusercontent.com/378023/36193236-6715e81a-11a8-11e8-8ec9-4b80c9c603ac.gif)

### Benefits

Easier to orient with multiple project roots and lots of files/folders.

### Possible Drawbacks

Scrolling performance suffers, not too bad, but still noticeably slower.

