### PR TITLE
Remove margin of icon only status-bar items

### DIFF
--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -82,4 +82,11 @@
       cursor: default;
     }
   }
+
+  // Remove margin for icon without text
+  status-bar-launch-mode::before, // Launch mode
+  .PortalStatusBarIndicator .icon::before, // Teletype
+  .icon.is-icon-only::before {
+    margin-right: 0;
+  }
 }


### PR DESCRIPTION
### Description of the Change

This removes the extra margin for status-bar tiles that only have an icon.

![36386667-82d352bc-1564-11e8-8891-0b483fb004a2](https://user-images.githubusercontent.com/378023/36784270-27fd59c2-1cc2-11e8-85a6-18e835c2f61a.png)

So far there are:

- [x] Launch status icon
- [x] Teletype icon

### Alternate Designs

Have an API that would enforce this automatically.

### Benefits

No extra margin.

### Possible Drawbacks

Hard to maintain since community packages need to be added manually.

### Applicable Issues

Closes #122
