### PR TITLE
Fix active pane marker

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -215,16 +215,19 @@
 
 // Active pane marker --------------
 
-atom-pane.active .tab.active:before {
-  content: "";
-  position: absolute;
-  pointer-events: none;
-  z-index: 2;
-  top: 0;
-  left: -1px; // cover left border
-  bottom: 0;
-  width: 2px;
-  background: @accent-color;
+atom-pane-axis > atom-pane.active,
+atom-pane-container > atom-pane.pane {
+  .tab.active:before {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    z-index: 2;
+    top: 0;
+    left: -1px; // cover left border
+    bottom: 0;
+    width: 2px;
+    background: @accent-color;
+  }
 }
 
 // hide marker in docks


### PR DESCRIPTION
Same as https://github.com/atom/one-dark-ui/pull/248/

I might still change my mind about only showing the marker when there is a split pane.