### PR TITLE
Fix sticky header from covering auto-revealed items

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -109,5 +109,11 @@
     &:focus .selected .project-root-header.project-root-header  {
       background: @button-background-color-selected;
     }
+
+    // Fix sticky header from covering auto-revealed items
+    .list-item.selected {
+      padding-top: @ui-tab-height;
+      margin-top: -@ui-tab-height;
+    }
   }
 }


### PR DESCRIPTION
Same as https://github.com/atom/one-dark-ui/pull/252