### PR TITLE
Change overlay background color

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -55,7 +55,7 @@
 @panel-heading-background-color:   @level-2-color;
 @panel-heading-border-color:       @base-border-color;
 
-@overlay-background-color:         @level-2-color;
+@overlay-background-color:         mix(@level-2-color, @level-3-color);
 @overlay-border-color:             @base-border-color;
 
 @button-background-color:          @level-1-color;


### PR DESCRIPTION
### Description of the Change

This PR changes the overlay background color to a mix between the editor and dock background.

### Alternate Designs

We could make it darker or even inverted, but since there is no variable for text colors in overlays, text contrast would suffer.

### Benefits

Overlays can be differentiated from inputs.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/378023/38543212-e51a616c-3cde-11e8-8e10-30e6859f12d5.png) | ![image](https://user-images.githubusercontent.com/378023/38543175-cc54ae76-3cde-11e8-9990-0a9a1a4d1de7.png)

### Possible Drawbacks

Yet another shade of grey.

### Applicable Issues

No issue, but reported by @kuychaco 
