### PR TITLE
Fix selected item not visible when using arrow up key

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -127,10 +127,22 @@
       background: @button-background-color-selected;
     }
 
-    // Fix sticky header from covering auto-revealed items
-    .list-item.selected {
+    // Fix sticky header from covering auto-revealed files
+    .entry.file.selected {
       padding-top: @ui-tab-height;
       margin-top: -@ui-tab-height;
+    }
+
+    // Fix sticky header from covering auto-revealed directories when using up/down keys
+    // for directories, scroll test moves to .header, see https://github.com/atom/tree-view/blob/d2857ad4d7eeb7dad5cf94b33257a8740211480e/lib/tree-view.coffee#L839
+    .entry.directory.selected:not(.project-root) {
+      & > .header {
+        padding-top: @ui-tab-height;
+        margin-top: -@ui-tab-height;
+      }
+      &::before {
+        margin-top: @ui-tab-height;
+      }
     }
   }
 }


### PR DESCRIPTION
### Description of the Change

This adds the same "hack" as https://github.com/atom/one-dark-ui/pull/252, but to a directory's `.header`, instead of the directory itself. The reason is because testing if it should be scrolled gets moved to the `.header`, see [tree-view.coffee#L839](https://github.com/atom/tree-view/blob/d2857ad4d7eeb7dad5cf94b33257a8740211480e/lib/tree-view.coffee#L839).

### Benefits

Selected directories are visible when using the ⬆️ key.

![tree-view](https://user-images.githubusercontent.com/378023/39285305-b259e45c-4952-11e8-9201-402544b2a513.gif)


### Possible Drawbacks

More hacks.

### Applicable Issues

Another follow-up fix for https://github.com/atom/one-dark-ui/pull/246
