### PR TITLE
More sticky header fixes

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -144,5 +144,14 @@
         margin-top: @ui-tab-height;
       }
     }
+
+    // Fix above directory is not being clickable
+    .entry.directory {
+      z-index: 1;
+      position: relative;
+      &.selected {
+        z-index: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description of the Change

This fixes an issue where the above item of a directory isn't clickable.

### Benefits

Above item is clickable again:

![tree-view](https://user-images.githubusercontent.com/378023/39466409-bb95cd64-4d63-11e8-93aa-ee496c666bd2.gif)

### Possible Drawbacks

Even more hacks, that might have other side effects.

### Applicable Issues

Fixes https://github.com/atom/one-dark-ui/issues/257
