### PR TITLE
Disable sticky headers by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "stickyHeaders": {
       "title": "Make tree-view project headers sticky",
       "type": "boolean",
-      "default": "true",
+      "default": "false",
       "order": 5
     }
   }


### PR DESCRIPTION
### Description of the Change

This changes the sticky header config to be disabled by default.

![image](https://user-images.githubusercontent.com/378023/39467166-8e64f24e-4d67-11e8-8eba-70600a4e232b.png)

### Benefits

Sticky headers help in orientation, especially with multiple root projects. Unfortunately a lot of hacks are needed and it seems quite unstable. Turning them off by default lets us test it a bit more.

### Possible Drawbacks

People might be surprised why they are gone.

### Applicable Issues

Carried over from https://github.com/atom/one-dark-ui/issues/257#issuecomment-385623746