### PR TITLE
Remove status-bar underline

### DIFF
--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -25,6 +25,7 @@
     vertical-align: top;
 
     &:hover {
+      text-decoration: none;
       background-color: @level-3-color-hover;
     }
     &:active {


### PR DESCRIPTION
### Description of the Change

This removes the underline of the GitHub package's status bar tiles.

![github-underline](https://user-images.githubusercontent.com/2766036/39833564-669eebf2-5398-11e8-8b05-669d31259517.gif)

### Benefits

There is already a hover effect. No need to have 2.

### Possible Drawbacks

None. It's a regression.

### Applicable Issues

Fixes https://github.com/atom/github/issues/1455
