### PR TITLE
Fix transparent sticky headers

### DIFF
--- a/styles/config.less
+++ b/styles/config.less
@@ -103,7 +103,7 @@
     .project-root-header {
       position: sticky;
       top: 0;
-      z-index: 1;
+      z-index: 2;
       padding-left: 5px;
       padding-right: 10px;
       border-bottom: 1px solid @base-border-color;


### PR DESCRIPTION
### Description of the Change

This increases the `z-index` on sticky headers so it covers the list items underneath.

### Benefits

Easier to read the text

### Possible Drawbacks

None

### Applicable Issues

Fixes https://github.com/atom/one-light-ui/issues/139
