### PR TITLE
Reset icons in select lists

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -63,6 +63,12 @@
     }
   }
 
+  // Reset icon to allow nesting
+  .icon {
+    display: initial;
+    height: initial;
+  }
+
   // We want to highlight the background of the list items because we dont
   // know their size.
   li.selected {


### PR DESCRIPTION
### Description of the Change

This resets `.icon` styles in `select-list`s.

### Benefits

Allows to can contain floated elements.

### Possible Drawbacks

None

### Applicable Issues

Fixes https://github.com/atom/one-light-ui/issues/137
