### PR TITLE
Update README to deprecate repository and redirect readers to atom/atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This package is now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/one-light-ui). Please direct all issues and pull requests there in the future!
+
+---
+
 ## One Light UI theme [![Build Status](https://travis-ci.org/atom/one-light-ui.svg?branch=master)](https://travis-ci.org/atom/one-light-ui)
 
 A light UI theme that adapts to most syntax themes.


### PR DESCRIPTION
With the changes in atom/atom#17924, the one-light-ui package now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/one-light-ui). This pull request updates the README to reflect that fact. We'll be archiving this repository shortly.

/cc https://github.com/atom/atom/issues/17856
/fyi @daviwil 